### PR TITLE
Fix #98 by checking if a valid PID is being killed

### DIFF
--- a/call.c
+++ b/call.c
@@ -407,7 +407,7 @@ void destroy_call (struct call *c)
      * voluntarily
      */
     pid = c->pppd;
-    if (pid)
+    if (pid > 0)
     {
       /* Set c->pppd to zero to prevent recursion with child_handler */
       c->pppd = 0;


### PR DESCRIPTION
When `start_ppd` fails, a PID of -1 is used in the `kill` command, causing catastrophic events.
